### PR TITLE
Add flexibility on input shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Here we report the most important hyperparameters that are used in GMM-MI.
         metric value is less than this threshold. Smaller values ensure that enough components are
         considered and that the data distribution is correctly captured, while taking longer to converge.
         Note this parameter can be degenerate with `threshold_fit`, and the two should be set 
-	together to reach a good density estimate of the data.
+        together to reach a good density estimate of the data.
     patience : int, default=1 
         Number of extra components to "wait" until convergence is declared. Must be at least 1.
         Same concept as patience when training a neural network. Higher value will fit models

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ PACKAGENAME = 'gmm_mi'
 
 setup(
     name='gmm_mi',
-    version="0.3.2",
+    version="0.3.3",
     author='Davide Piras',
     author_email='dr.davide.piras@gmail.com',
     description='Estimate mutual information distribution with Gaussian mixture models',


### PR DESCRIPTION
Now users can pass either an input array with shape `(n_samples, 2)` or two 1D arrays with shape `(n_samples, 1)` or `(n_samples)`. Also fixed a typo in the README, and slightly extended the tests.